### PR TITLE
Don't touch vim registers holding deletions.

### DIFF
--- a/plugin/lawrencium.vim
+++ b/plugin/lawrencium.vim
@@ -388,7 +388,7 @@ function! s:HgRepo.ReadCommandOutput(command, ...) abort
             " must open them all first otherwise we could delete the whole
             " contents of the last fold (since Vim may close them all by
             " default).
-            normal! zRGdd
+            normal! zRG"_dd
         endif
     endfunction
 


### PR DESCRIPTION
(Fix commit c02360b5f... where typing 'p' after :Hgvdiff would paste a
blank line and not what the user had previously deleted.)
