### PR TITLE
show commit message in annotate window on <Leader><cr>

### DIFF
--- a/doc/lawrencium.txt
+++ b/doc/lawrencium.txt
@@ -474,6 +474,9 @@ is set to `0`.
 :Hgannotatediffsum      Show a diff summary (similar to |:Hgdiffsum|) for the
                         revision mentioned under the cursor.
                         Mapped to |<CR>|.
+:Hgannotatelog          Show the complete commit for the revision mentioned
+                        under the cursor.
+                        Mapped to <Leader><CR>.
 
 
 


### PR DESCRIPTION
Hi,
i find it useful, to also see the complete commit, when working with annotated window. So I added this possibility when pressing <leader><cr>.
I tried to follow style of the plugin, so please include.