### PR TITLE
Fix :Hgvdiff with a file that is a copy.

### DIFF
--- a/autoload/lawrencium/cat.vim
+++ b/autoload/lawrencium/cat.vim
@@ -8,7 +8,20 @@ function! lawrencium#cat#read(repo, path_parts, full_path) abort
     if l:rev == ''
         call a:repo.ReadCommandOutput('cat', a:full_path)
     else
-        call a:repo.ReadCommandOutput('cat', '-r', l:rev, a:full_path)
+        call a:repo.ReadCommandOutput('cat', '-r', l:rev, s:absolute_pathname(a:repo, a:full_path, l:rev))
     endif
 endfunction
 
+function! s:absolute_pathname(repo, current_absolute_pathname, revision)
+    if a:revision ==# 'p1()'
+        let name_of_copied_file = matchstr(
+                    \ a:repo.RunCommand('status', '--copies', a:current_absolute_pathname),
+                    \ "^A [^\n]\\+\n  \\zs[^\n]\\+")
+        if !empty(name_of_copied_file)
+            return a:repo.root_dir . '/' . name_of_copied_file
+        endif
+    else
+        " TODO: handle a:revision != 'p1()'
+    endif
+    return a:current_absolute_pathname
+endfunction


### PR DESCRIPTION
Previously,
    :Hg rename old new
    :" (A rename is a copy and a deletion of the file with the old name.)
    :edit new
    :Hgvdiff
    " "new: no such file in rev NNNN" was displayed in the window to the right of the new vertical split.

Now :Hgvdiff diffs new with old from the head revision.